### PR TITLE
fix  bug in landscape apps that caused to launch multiple PaymentActi…

### DIFF
--- a/poolakeyunitysdk-android/poolakey/src/main/java/com/farsitel/bazaar/PaymentActivity.kt
+++ b/poolakeyunitysdk-android/poolakey/src/main/java/com/farsitel/bazaar/PaymentActivity.kt
@@ -17,6 +17,12 @@ class PaymentActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (savedInstanceState != null){
+            finish()
+            return
+        }
+
         initArgs()
         when (command) {
             Command.PurchaseProduct -> purchaseProduct()


### PR DESCRIPTION
سلام،
تو بازی های حالت Landscape وقتی روی دکمه پرداخت می زدیم با چرخاندن گوشی تمام ویوو دوباره ساخته میشد و اگر در حالت Portrait صفحه پرداخت رو می بستیم یکی دیگه دوباره باز میشد. کلا تو بازی های Landscape هر گونه چرخاندن گوشی مشکل ایجاد می کرد و پروسه خرید رو مختل می کرد. با این تیکه کد این قضیه درست میشه.

با احترام